### PR TITLE
adding a Makefile and use circleci 2.1 matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,9 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       os=`uname`
-       artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
+       #os=`uname`
+       #artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
+       artifacts_dir="artifacts/artifacts.${OS_NAME}.py_${PY_VER}"
        #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
        echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER"
        make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER
@@ -144,6 +145,7 @@ jobs:
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
+         OS_NAME: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,8 @@ aliases:
        UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
        #anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
        ls -l $PWD/artifacts
-       make conda-upload conda=$WORKDIR/miniconda/bin/conda artifact_dir="$PWD/artifacts/*/"
+       echo "make conda-upload $UPLOAD_OPTIONS conda=$WORKDIR/miniconda/bin/conda artifact_dir=\"$PWD/artifacts/*/\""
+       make conda-upload $UPLOAD_OPTIONS conda=$WORKDIR/miniconda/bin/conda artifact_dir="$PWD/artifacts/*/"
 
 executors:
    linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
+         OS: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:
@@ -149,14 +150,8 @@ jobs:
                  #- workdir/*/miniconda
 
    upload:
-      parameters:
-         os:
-            type: executor
-         py_ver:
-            type: string
-      executor: << parameters.os >>
-      #machine:
-      #   image: circleci/classic:latest
+      machine:
+         image: circleci/classic:latest
       environment:
          PKG_NAME: << pipeline.parameters.pkg_name >>
          VERSION: << pipeline.parameters.last_stable >>
@@ -189,13 +184,6 @@ workflows:
                  - rerender-<< matrix.os >>
 
          - upload:
-              matrix:
-                 parameters:
-                    os: [ linux, macos ]
-                    py_ver: [ "3.6", "3.7", "3.8" ]
-              name: upload-<< matrix.os >>-<< matrix.py_ver >>
               requires:
-                 - build_test-<< matrix.os >>-<< matrix.py_ver >>
-
-
+                 - build_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,10 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-
-       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
+       os=`uname`
+       artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"       
+       #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
+       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts_dir build_version=$PY_VER
 
   - &setup_run_tests
     name: setup_run_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
-         #OS: << parameters.os >>
+         OS_EX: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,8 @@ jobs:
          REPO_NAME: << pipeline.parameters.repo_name >>
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
+         OS: << parameters.os >>
          PY_VER: << parameters.py_ver >>
-         OS_EX: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,11 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        os=`uname`
-       artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"       
+       artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
        #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
+       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts_dir build_version=$PY_VER"
        make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts_dir build_version=$PY_VER
+       ls -l $artifacts_dir
 
   - &setup_run_tests
     name: setup_run_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
 
-       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
+       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL"
        #anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
        ls -l $PWD/artifacts
        echo "make conda-upload $UPLOAD_OPTIONS conda=$WORKDIR/miniconda/bin/conda artifact_dir=\"$PWD/artifacts/*/\""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ aliases:
        os=`uname`
        artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
        #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
-       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER"
-       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER
+       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER"
+       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER
        pwd
        ls
        echo "....ls -l artifacts"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ aliases:
        #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
        echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER"
        make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER
-       ls -l artifacts
+       ls -l $PWD/artifacts
        ls -l $artifacts_dir
 
   - &setup_run_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,11 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate $ENV_NAME
-       make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME
+       if [ `uname` == "Linux" and  ] && [ $PY_VER == "3.7" ]; then
+          make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME coverage=1
+       else
+          make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME
+       fi
 
   - &conda_upload
     name: conda_upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ aliases:
        ls -l $PWD/artifacts
        #UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
        #anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
-       make conda-upload conda=$WORKDIR/miniconda/bin/conda conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL artifact_dir=$PWD/artifacts       
+       make conda-upload conda=$WORKDIR/miniconda/bin/conda conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL artifact_dir=$PWD/artifacts
 
 executors:
    linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,9 @@ aliases:
        os=`uname`
        artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
        #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
-       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts_dir build_version=$PY_VER"
-       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts_dir build_version=$PY_VER
+       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER"
+       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER
+       ls -l artifacts
        ls -l $artifacts_dir
 
   - &setup_run_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,6 @@ jobs:
          REPO_NAME: << pipeline.parameters.repo_name >>
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
-         OS: << parameters.os >>
          PY_VER: << parameters.py_ver >>
       steps:
          - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate $ENV_NAME
-       if [ `uname` == "Linux" and  ] && [ $PY_VER == "3.7" ]; then
-          make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME coverage=1
-       else
-          make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME
-       fi
+       make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME coverage=1
 
   - &conda_upload
     name: conda_upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        make conda-rerender conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR last_stable=$LAST_STABLE branch=$CIRCLE_BRANCH
-       ([ $? -eq 0 ] && echo "success!") || echo "failure!"
 
   - &conda_build
     name: conda_build
@@ -168,7 +167,6 @@ jobs:
          - run: *conda_upload
 
 workflows:
-   version: 2.1
    cdtime:
       jobs:
          - rerender:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,10 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
 
-       UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
-       anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
+       #anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       ls -l $PWD/artifacts
+       make conda-upload conda=$WORKDIR/miniconda/bin/conda artifact_dir="$PWD/artifacts/*/"
 
 executors:
    linux:
@@ -149,6 +151,7 @@ jobs:
               paths: 
                  - workdir/*/miniconda/conda-bld/*/cdtime*bz2
                  #- workdir/*/miniconda
+                 - artifacts
 
    upload:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       artifacts_dir="artifacts/artifacts.${OS}.py_${PY_VER}"
-       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts_dir build_version=$PY_VER
+
+       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
 
   - &setup_run_tests
     name: setup_run_tests
@@ -86,10 +86,9 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       ls -l $PWD/artifacts
-       # UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
-       # anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
-       # make conda-upload conda=$WORKDIR/miniconda/bin/conda conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL artifact_dir=$PWD/artifacts
+
+       UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
+       anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
 executors:
    linux:
@@ -132,7 +131,6 @@ jobs:
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
-         OS: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:
@@ -148,11 +146,17 @@ jobs:
               root: .
               paths: 
                  - workdir/*/miniconda/conda-bld/*/cdtime*bz2
-                 - artifacts
+                 #- workdir/*/miniconda
 
    upload:
-      machine:
-         image: circleci/classic:latest
+      parameters:
+         os:
+            type: executor
+         py_ver:
+            type: string
+      executor: << parameters.os >>
+      #machine:
+      #   image: circleci/classic:latest
       environment:
          PKG_NAME: << pipeline.parameters.pkg_name >>
          VERSION: << pipeline.parameters.last_stable >>
@@ -185,8 +189,13 @@ workflows:
                  - rerender-<< matrix.os >>
 
          - upload:
+              matrix:
+                 parameters:
+                    os: [ linux, macos ]
+                    py_ver: [ "3.6", "3.7", "3.8" ]
+              name: upload-<< matrix.os >>-<< matrix.py_ver >>
               requires:
-                 - build_test
+                 - build_test-<< matrix.os >>-<< matrix.py_ver >>
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,12 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export CONDA_PY_VER="python=$PY_VER"
+       os=`uname`
+       artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
        echo "make setup-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME extra_pkgs=\"$CONDA_PY_VER $COVERAGE_PKGS\""
        make setup-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME extra_pkgs="$CONDA_PY_VER $COVERAGE_PKGS"
 
-       make conda-dump-env conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME artifact_dir=$PWD/artifacts conda_env_name=$CIRCLE_JOB
+       make conda-dump-env conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME artifact_dir=$PWD/$artifacts_dir conda_env_name=$CIRCLE_JOB
 
   - &run_tests
     name: run_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
-         OS: << parameters.os >>
+         #OS: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate $ENV_NAME
-       make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME coverage=1
+       make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME
 
   - &conda_upload
     name: conda_upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,304 +1,201 @@
-version: 2
+version: 2.1
+
+parameters:
+   pkg_name:
+      type: string
+      default: "cdtime"
+   repo_name:
+      type: string
+      default: "cdtime"
+   last_stable:
+      type: string
+      default: "3.1.2"
+   user:
+      type: string
+      default: "cdat"
+   label:
+      type: string
+      default: "nightly"
+   env_name:
+      type: string
+      default: "test_cdtime"
 
 aliases:
+  - &setup_env
+    name: setup_env
+    command: |
+       if [[ `uname` == "Darwin" ]]; then
+          echo 'export WORKDIR=/Users/distiller/project/workdir/macos' >> $BASH_ENV
+       else
+          echo 'export WORKDIR=/home/circleci/project/workdir/linux' >> $BASH_ENV
+       fi
+       source $BASH_ENV
+       mkdir -p $WORKDIR
+
   - &setup_miniconda
     name: setup_miniconda
     command: |
-       mkdir -p workspace
-       git clone -b validateNightlyNew git@github.com:CDAT/cdat workspace/cdat
+       source $BASH_ENV
+       mkdir -p $WORKDIR
+       git clone -b validateNightlyNew https://github.com/CDAT/cdat.git $WORKDIR/cdat
        # install_miniconda.py installs miniconda3 under $WORKDIR/miniconda
-       python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
+       python $WORKDIR/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
 
   - &conda_rerender
     name: conda_rerender
     command: |
-       git clone https://github.com/CDAT/conda-recipes.git $WORKDIR/conda-recipes 
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       BUILD_SCRIPT="$WORKDIR/conda-recipes/build_tools/conda_build.py"
-       python $BUILD_SCRIPT -w $WORKDIR -l $LAST_STABLE -B 0 -p $PKG_NAME -b $CIRCLE_BRANCH --do_rerender
+       echo "make conda-rerender conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR last_stable=$LAST_STABLE branch=$CIRCLE_BRANCH"
+       make conda-rerender conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR last_stable=$LAST_STABLE branch=$CIRCLE_BRANCH
+       ([ $? -eq 0 ] && echo "success!") || echo "failure!"
 
   - &conda_build
     name: conda_build
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       conda config --add channels conda-forge --force
-       conda config --add channels cdat/label/nightly --force
-       conda config --set channel_priority strict
-       cat ~/.condarc
-       BUILD_SCRIPT="$WORKDIR/conda-recipes/build_tools/conda_build.py"
-       python $BUILD_SCRIPT -w $WORKDIR -p $PKG_NAME --build_version $BUILD_VARIANT_VER --do_build
+
+       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
 
   - &setup_run_tests
     name: setup_run_tests
-    environment:
-       PKGS: "numpy cdat_info libcdms libdrs_f testsrunner"
-       CHANNELS: "-c cdat/label/nightly -c conda-forge"
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       conda create -y -n $ENV_NAME --use-local $CHANNELS "$CONDA_PY_VER" $PKG_NAME $PKGS
-       conda activate $ENV_NAME
-       conda list
+       export CONDA_PY_VER="python=$PY_VER"
+       echo "make setup-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME extra_pkgs=\"$CONDA_PY_VER $COVERAGE_PKGS\""
+       make setup-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME extra_pkgs="$CONDA_PY_VER $COVERAGE_PKGS"
+
+       make conda-dump-env conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME artifact_dir=$PWD/artifacts conda_env_name=$CIRCLE_JOB
 
   - &run_tests
     name: run_tests
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate $ENV_NAME
-       python run_tests.py -H -v2
+       make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME
 
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != "master" ]]; then
-          exit 0
-       fi
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
-       anaconda $UPLOAD_OPTIONS linux_build/miniconda/conda-bld/linux-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
-       anaconda $UPLOAD_OPTIONS macos_build/miniconda/conda-bld/osx-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
-jobs:
-   macos_setup:
+       UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
+       anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+
+executors:
+   linux:
+      machine:
+         image: circleci/classic:latest
+   macos:
       macos:
          xcode: "11.4.0"
+
+jobs:
+   setup_rerender:
+      parameters:
+         os:
+            type: executor
+      executor: << parameters.os >>
       environment:
-         WORKDIR: /Users/distiller/project/macos_build
-         PKG_NAME: "cdtime"
-         LAST_STABLE: "3.1.2"
+         PKG_NAME: << pipeline.parameters.pkg_name >>
+         REPO_NAME: << pipeline.parameters.repo_name >>
+         LAST_STABLE: << pipeline.parameters.last_stable >>
       steps:
          - checkout
+         - run: *setup_env
          - run: *setup_miniconda
          - run: *conda_rerender
          - persist_to_workspace:
               root: .
               paths: 
-                 - macos_build
+                 - workdir
 
-   linux_setup:
-      machine:
-         image: circleci/classic:latest
+   build_test:
+      parameters:
+         os:
+            type: executor
+         py_ver:
+            type: string
+      executor: << parameters.os >>
       environment:
-         WORKDIR: /home/circleci/project/linux_build
-         PKG_NAME: "cdtime"
-         LAST_STABLE: "3.1.2"
-      steps:
-         - checkout
-         - run: *setup_miniconda
-         - run: *conda_rerender
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - linux_build
-
-   macos_cdtime_py36:
-      macos:
-         xcode: "11.4.0"
-      environment:
-         WORKDIR: /Users/distiller/project/macos_build
-         PKG_NAME: "cdtime"
-         ENV_NAME: "test_cdtime"
-         CONDA_PY_VER: "python>=3.6,<3.7"
-         BUILD_VARIANT_VER: "3.6"
+         PKG_NAME: << pipeline.parameters.pkg_name >>
+         REPO_NAME: << pipeline.parameters.repo_name >>
+         LAST_STABLE: << pipeline.parameters.last_stable >>
+         ENV_NAME: << pipeline.parameters.env_name >>
+         PY_VER: << parameters.py_ver >>
       steps:
          - checkout
          - attach_workspace:
               at: .
+         - run: *setup_env
          - run: *conda_build
          - run: *setup_run_tests
          - run: *run_tests
          - store_artifacts:
               path: tests_html
               destination: tests_html
-         - store_artifacts:
-             path: tests_png
-             destination: tests_png
          - persist_to_workspace:
               root: .
-              paths:
-                 - macos_build/miniconda/conda-bld/osx-64/cdtime*tar.bz2
-
-   macos_cdtime_py37:
-      macos:
-         xcode: "11.4.0"
-      environment:
-         WORKDIR: /Users/distiller/project/macos_build
-         PKG_NAME: "cdtime"
-         ENV_NAME: "test_cdtime"
-         CONDA_PY_VER: "python>=3.7,<3.8"
-         BUILD_VARIANT_VER: "3.7"
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
-         - store_artifacts:
-             path: tests_png
-             destination: tests_png
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - macos_build/miniconda/conda-bld/osx-64/cdtime*tar.bz2
-
-   macos_cdtime_py38:
-      macos:
-         xcode: "11.4.0"
-      environment:
-         WORKDIR: /Users/distiller/project/macos_build
-         PKG_NAME: "cdtime"
-         ENV_NAME: "test_cdtime"
-         CONDA_PY_VER: "python>=3.8,<3.9"
-         BUILD_VARIANT_VER: "3.8"
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
-         - store_artifacts:
-             path: tests_png
-             destination: tests_png
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - macos_build/miniconda/conda-bld/osx-64/cdtime*tar.bz2
-
-   linux_cdtime_py36:
-      machine:
-         image: circleci/classic:latest
-      environment:
-         WORKDIR: /home/circleci/project/linux_build
-         PKG_NAME: "cdtime"
-         ENV_NAME: "test_cdtime"
-         CONDA_PY_VER: "python>=3.6,<3.7"
-         BUILD_VARIANT_VER: "3.6"
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
-         - store_artifacts:
-             path: tests_png
-             destination: tests_png
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - linux_build/miniconda/conda-bld/linux-64/cdtime*tar.bz2
-
-   linux_cdtime_py37:
-      machine:
-         image: circleci/classic:latest
-      environment:
-         WORKDIR: /home/circleci/project/linux_build
-         PKG_NAME: "cdtime"
-         ENV_NAME: "test_cdtime"
-         CONDA_PY_VER: "python>=3.7,<3.8"
-         BUILD_VARIANT_VER: "3.7"
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
-         - store_artifacts:
-             path: tests_png
-             destination: tests_png
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - linux_build/miniconda/conda-bld/linux-64/cdtime*tar.bz2
-
-   linux_cdtime_py38:
-      machine:
-         image: circleci/classic:latest
-      environment:
-         WORKDIR: /home/circleci/project/linux_build
-         PKG_NAME: "cdtime"
-         ENV_NAME: "test_cdtime"
-         CONDA_PY_VER: "python>=3.8,<3.9"
-         BUILD_VARIANT_VER: "3.8"
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
-         - store_artifacts:
-             path: tests_png
-             destination: tests_png
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - linux_build/miniconda/conda-bld/linux-64/cdtime*tar.bz2
+              paths: 
+                 - workdir/*/miniconda/conda-bld/*/cdtime*bz2
+                 #- workdir/*/miniconda
 
    upload:
-      machine:
-         image: circleci/classic:latest
+      parameters:
+         os:
+            type: executor
+         py_ver:
+            type: string
+      executor: << parameters.os >>
+      #machine:
+      #   image: circleci/classic:latest
       environment:
-         WORKDIR: /home/circleci/project/linux_build
-         PKG_NAME: "cdtime"
-         VERSION: "3.1.2"
-         USER: "cdat"
-         LABEL: "nightly"
+         PKG_NAME: << pipeline.parameters.pkg_name >>
+         VERSION: << pipeline.parameters.last_stable >>
+         USER: << pipeline.parameters.user >>
+         LABEL: << pipeline.parameters.label >>
       steps:
+         - checkout
          - attach_workspace:
               at: .
+         - run: *setup_env
          - run: *conda_upload
 
 workflows:
-   version: 2
+   version: 2.1
    cdtime:
       jobs:
-         - macos_setup
-         - linux_setup
-         - macos_cdtime_py36:
+         - setup_rerender:
+              matrix:
+                 parameters:
+                    os: [ linux, macos ]
+              name: rerender-<< matrix.os >>
+
+         - build_test:
+              matrix:
+                 parameters:
+                    os: [ linux, macos ]
+                    py_ver: [ "3.6", "3.7", "3.8" ]
+              name: build_test-<< matrix.os >>-<< matrix.py_ver >>
               requires:
-                 - macos_setup
-         - macos_cdtime_py37:
-              requires:
-                 - macos_setup
-         - macos_cdtime_py38:
-              requires:
-                 - macos_setup
-         - linux_cdtime_py36:
-              requires:
-                 - linux_setup
-         - linux_cdtime_py37:
-              requires:
-                 - linux_setup
-         - linux_cdtime_py38:
-              requires:
-                 - linux_setup
+                 - rerender-<< matrix.os >>
+
          - upload:
+              matrix:
+                 parameters:
+                    os: [ linux, macos ]
+                    py_ver: [ "3.6", "3.7", "3.8" ]
+              name: upload-<< matrix.os >>-<< matrix.py_ver >>
               requires:
-                 - macos_cdtime_py36
-                 - macos_cdtime_py37
-                 - macos_cdtime_py38
-                 - linux_cdtime_py36
-                 - linux_cdtime_py37
-                 - linux_cdtime_py38
+                 - build_test-<< matrix.os >>-<< matrix.py_ver >>
+
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-
-       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
+       artifacts_dir="artifacts/artifacts.${OS}.py_${PY_VER}"
+       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts_dir build_version=$PY_VER
 
   - &setup_run_tests
     name: setup_run_tests
@@ -86,9 +86,10 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-
-       UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
-       anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       ls -l $PWD/artifacts
+       #UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
+       #anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       make conda-upload conda=$WORKDIR/miniconda/bin/conda conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL artifact_dir=$PWD/artifacts       
 
 executors:
    linux:
@@ -131,6 +132,7 @@ jobs:
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
+         OS: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:
@@ -146,17 +148,11 @@ jobs:
               root: .
               paths: 
                  - workdir/*/miniconda/conda-bld/*/cdtime*bz2
-                 #- workdir/*/miniconda
+                 - artifacts
 
    upload:
-      parameters:
-         os:
-            type: executor
-         py_ver:
-            type: string
-      executor: << parameters.os >>
-      #machine:
-      #   image: circleci/classic:latest
+      machine:
+         image: circleci/classic:latest
       environment:
          PKG_NAME: << pipeline.parameters.pkg_name >>
          VERSION: << pipeline.parameters.last_stable >>
@@ -189,13 +185,8 @@ workflows:
                  - rerender-<< matrix.os >>
 
          - upload:
-              matrix:
-                 parameters:
-                    os: [ linux, macos ]
-                    py_ver: [ "3.6", "3.7", "3.8" ]
-              name: upload-<< matrix.os >>-<< matrix.py_ver >>
               requires:
-                 - build_test-<< matrix.os >>-<< matrix.py_ver >>
+                 - build_test
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,6 @@ jobs:
       machine:
          image: circleci/classic:latest
       environment:
-         PKG_NAME: << pipeline.parameters.pkg_name >>
-         VERSION: << pipeline.parameters.last_stable >>
          USER: << pipeline.parameters.user >>
          LABEL: << pipeline.parameters.label >>
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,9 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        ls -l $PWD/artifacts
-       #UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
-       #anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
-       make conda-upload conda=$WORKDIR/miniconda/bin/conda conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL artifact_dir=$PWD/artifacts
+       # UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
+       # anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       # make conda-upload conda=$WORKDIR/miniconda/bin/conda conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL artifact_dir=$PWD/artifacts
 
 executors:
    linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ aliases:
        os=`uname`
        artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
        #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
-       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER"
-       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER
+       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER"
+       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER
        ls -l artifacts
        ls -l $artifacts_dir
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ executors:
          xcode: "11.4.0"
 
 jobs:
-   setup_rerender:
+   rerender:
       parameters:
          os:
             type: executor
@@ -171,7 +171,7 @@ workflows:
    version: 2.1
    cdtime:
       jobs:
-         - setup_rerender:
+         - rerender:
               matrix:
                  parameters:
                     os: [ linux, macos ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       echo "make conda-rerender conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR last_stable=$LAST_STABLE branch=$CIRCLE_BRANCH"
        make conda-rerender conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR last_stable=$LAST_STABLE branch=$CIRCLE_BRANCH
        ([ $? -eq 0 ] && echo "success!") || echo "failure!"
 
@@ -57,17 +56,9 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       #os=`uname`
-       #artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
-       artifacts_dir="artifacts/artifacts.${OS_NAME}.py_${PY_VER}"
-       #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
-       echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER"
+       os=`uname`
+       artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
        make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER
-       pwd
-       ls
-       echo "....ls -l artifacts"
-       ls -l artifacts
-       ls -l $artifacts_dir
 
   - &setup_run_tests
     name: setup_run_tests
@@ -78,10 +69,9 @@ aliases:
        export CONDA_PY_VER="python=$PY_VER"
        os=`uname`
        artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
-       echo "make setup-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME extra_pkgs=\"$CONDA_PY_VER $COVERAGE_PKGS\""
        make setup-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME extra_pkgs="$CONDA_PY_VER $COVERAGE_PKGS"
 
-       make conda-dump-env conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME artifact_dir=$PWD/$artifacts_dir conda_env_name=$CIRCLE_JOB
+       make conda-dump-env conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME artifact_dir=spec_artifacts conda_env_filename=$CIRCLE_JOB
 
   - &run_tests
     name: run_tests
@@ -99,9 +89,6 @@ aliases:
        conda activate base
 
        UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL"
-       #anaconda $UPLOAD_OPTIONS $WORKDIR/miniconda/conda-bld/*-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
-       ls -l $PWD/artifacts
-       echo "make conda-upload $UPLOAD_OPTIONS conda=$WORKDIR/miniconda/bin/conda artifact_dir=\"$PWD/artifacts/*/\""
        make conda-upload $UPLOAD_OPTIONS conda=$WORKDIR/miniconda/bin/conda artifact_dir="$PWD/artifacts/*/"
 
 executors:
@@ -145,7 +132,6 @@ jobs:
          LAST_STABLE: << pipeline.parameters.last_stable >>
          ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
-         OS_NAME: << parameters.os >>
       steps:
          - checkout
          - attach_workspace:
@@ -157,11 +143,13 @@ jobs:
          - store_artifacts:
               path: tests_html
               destination: tests_html
+         - store_artifacts:
+              path: spec_artifacts
+              destination: spec_artifacts
          - persist_to_workspace:
               root: .
               paths: 
                  - workdir/*/miniconda/conda-bld/*/cdtime*bz2
-                 #- workdir/*/miniconda
                  - artifacts
 
    upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,10 @@ aliases:
        #make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/artifacts build_version=$PY_VER
        echo "make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER"
        make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR copy_conda_package=$PWD/$artifacts_dir build_version=$PY_VER
-       ls -l $PWD/artifacts
+       pwd
+       ls
+       echo "....ls -l artifacts"
+       ls -l artifacts
        ls -l $artifacts_dir
 
   - &setup_run_tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,84 @@
+.PHONY: conda-info conda-list setup-build setup-tests conda-rerender \
+	conda-build conda-upload conda-dump-env conda-cp-output get_testdata \
+	run-tests run-coveralls
+
+SHELL = /bin/bash
+
+os = $(shell uname)
+pkg_name = cdtime
+build_script = conda-recipes/build_tools/conda_build.py
+
+test_pkgs = numpy cdat_info libcdms libdrs_f testsrunner
+last_stable ?= 3.1.2
+
+conda_env ?= base
+workdir ?= $(PWD)/workspace
+branch ?= $(shell git rev-parse --abbrev-ref HEAD)
+extra_channels ?= cdat/label/nightly conda-forge
+conda ?= $(or $(CONDA_EXE),$(shell find /opt/*conda*/bin $(HOME)/*conda* -type f -iname conda))
+artifact_dir ?= $(PWD)/artifacts
+conda_env_filename ?= spec-file
+build_version ?= 3.7
+
+ifneq ($(coverage),)
+coverage = -c tests/coverage.json --coverage-from-egg
+endif
+
+# TODO change back to master
+conda_recipes_branch ?= build_tool_update.2
+
+conda_base = $(patsubst %/bin/conda,%,$(conda))
+conda_activate = $(conda_base)/bin/activate
+
+ifdef $(artifact_dir)
+conda_build_extra = --copy_conda_package $(artifact_dir)/
+endif
+
+ifndef $(local_repo)
+local_repo = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+endif
+
+conda-info:
+	source $(conda_activate) $(conda_env); conda info
+
+conda-list:
+	source $(conda_activate) $(conda_env); conda list
+
+setup-build:
+ifeq ($(wildcard $(workdir)/conda-recipes),)
+	git clone -b $(conda_recipes_branch) https://github.com/CDAT/conda-recipes $(workdir)/conda-recipes
+else
+	cd $(workdir)/conda-recipes; git pull
+endif
+
+setup-tests:
+	source $(conda_activate) base; conda create -y -n $(conda_env) --use-local \
+		$(foreach x,$(extra_channels),-c $(x)) $(pkg_name) $(foreach x,$(test_pkgs),"$(x)") $(foreach x,$(extra_pkgs),"$(x)")
+
+conda-rerender: setup-build 
+	python $(workdir)/$(build_script) -w $(workdir) -l $(last_stable) -B 0 -p $(pkg_name) \
+		-b $(branch) --do_rerender --conda_env $(conda_env) --ignore_conda_missmatch \
+		--conda_activate $(conda_activate)
+
+conda-build:
+	mkdir -p $(artifact_dir)
+
+	python $(workdir)/$(build_script) -w $(workdir) -p $(pkg_name) --build_version $(build_version) \
+		--do_build --conda_env $(conda_env) --extra_channels $(extra_channels) \
+		--conda_activate $(conda_activate) $(conda_build_extra)
+
+conda-upload:
+	source $(conda_activate) $(conda_env); \
+		output=$$(conda build --output $(workdir)/$(pkg_name)-feedstock); \
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) $${output} --force
+
+conda-dump-env:
+	mkdir -p $(artifact_dir)
+
+	source $(conda_activate) $(conda_env); conda list --explicit > $(artifact_dir)/$(conda_env_filename).txt
+
+run-tests:
+	source $(conda_activate) $(conda_env); python run_tests.py -H -v2 $(coverage)
+
+run-coveralls:
+	source $(conda_activate) $(conda_env); coveralls;

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ conda-build:
 
 conda-upload:
 	source $(conda_activate) $(conda_env); \
-		output=$$(conda build --output $(workdir)/$(pkg_name)-feedstock); \
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) $${output} --force
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,12 @@ conda-build:
 
 	python $(workdir)/$(build_script) -w $(workdir) -p $(pkg_name) --build_version $(build_version) \
 		--do_build --conda_env $(conda_env) --extra_channels $(extra_channels) \
-		--conda_activate $(conda_activate) $(conda_build_extra) \
-		--copy_conda_package $(artifact_dir)/
+		--conda_activate $(conda_activate) $(conda_build_extra)
 
 conda-upload:
-	source $(conda_activate) $(conda_env); \                                                                 
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*/
+	source $(conda_activate) $(conda_env); \
+		output=$$(conda build --output $(workdir)/$(pkg_name)-feedstock); \
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) $${output} --force
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,16 @@ conda-build:
 
 	python $(workdir)/$(build_script) -w $(workdir) -p $(pkg_name) --build_version $(build_version) \
 		--do_build --conda_env $(conda_env) --extra_channels $(extra_channels) \
-		--conda_activate $(conda_activate) $(conda_build_extra)
+		--conda_activate $(conda_activate) $(conda_build_extra) \
+		--copy_conda_package $(artifact_dir)/
 
+#conda-upload:
+#	source $(conda_activate) $(conda_env); \
+#		output=$$(conda build --output $(workdir)/$(pkg_name)-feedstock); \
+#		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) $${output} --force
 conda-upload:
-	source $(conda_activate) $(conda_env); \
-		output=$$(conda build --output $(workdir)/$(pkg_name)-feedstock); \
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) $${output} --force
+        source $(conda_activate) $(conda_env); \                                                                 
+                anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ conda-build:
 
 conda-upload:
 	source $(conda_activate) $(conda_env); \                                                                 
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*/
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)

--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,9 @@ conda-build:
 		--conda_activate $(conda_activate) $(conda_build_extra) \
 		--copy_conda_package $(artifact_dir)/
 
-#conda-upload:
-#	source $(conda_activate) $(conda_env); \
-#		output=$$(conda build --output $(workdir)/$(pkg_name)-feedstock); \
-#		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) $${output} --force
 conda-upload:
-        source $(conda_activate) $(conda_env); \                                                                 
-                anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*
+	source $(conda_activate) $(conda_env); \                                                                 
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ conda-build:
 
 conda-upload:
 	source $(conda_activate) $(conda_env); \
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*/*.tar.bz2
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*.tar.bz2
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,7 @@ conda_recipes_branch ?= build_tool_update
 conda_base = $(patsubst %/bin/conda,%,$(conda))
 conda_activate = $(conda_base)/bin/activate
 
-ifdef $(artifact_dir)
 conda_build_extra = --copy_conda_package $(artifact_dir)/
-endif
 
 ifndef $(local_repo)
 local_repo = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ coverage = -c tests/coverage.json --coverage-from-egg
 endif
 
 # TODO change back to master
-conda_recipes_branch ?= build_tool_update.2
+#conda_recipes_branch ?= build_tool_update.2
+conda_recipes_branch ?= build_tool_update
 
 conda_base = $(patsubst %/bin/conda,%,$(conda))
 conda_activate = $(conda_base)/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: conda-info conda-list setup-build setup-tests conda-rerender \
-	conda-build conda-upload conda-dump-env conda-cp-output get_testdata \
+	conda-build conda-upload conda-dump-env \
 	run-tests run-coveralls
 
 SHELL = /bin/bash
@@ -25,7 +25,6 @@ coverage = -c tests/coverage.json --coverage-from-egg
 endif
 
 # TODO change back to master
-#conda_recipes_branch ?= build_tool_update.2
 conda_recipes_branch ?= build_tool_update
 
 conda_base = $(patsubst %/bin/conda,%,$(conda))
@@ -52,7 +51,8 @@ endif
 
 setup-tests:
 	source $(conda_activate) base; conda create -y -n $(conda_env) --use-local \
-		$(foreach x,$(extra_channels),-c $(x)) $(pkg_name) $(foreach x,$(test_pkgs),"$(x)") $(foreach x,$(extra_pkgs),"$(x)")
+		$(foreach x,$(extra_channels),-c $(x)) $(pkg_name) $(foreach x,$(test_pkgs),"$(x)") \
+		$(foreach x,$(extra_pkgs),"$(x)")
 
 conda-rerender: setup-build 
 	python $(workdir)/$(build_script) -w $(workdir) -l $(last_stable) -B 0 -p $(pkg_name) \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ conda-build:
 
 conda-upload:
 	source $(conda_activate) $(conda_env); \
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*/*.tar.bz2
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)


### PR DESCRIPTION
add a Makefile and 'build_tool_update.2' branch of conda-recipes (temporarily) till that branch is merged.
use circleci 2.1 matrix to simplify workflow.
@jasonb5   I am not using conda-upload target of Makefile in upload in the workflow because then I will need to persist the whole miniconda directory to the workpace, and attach_to_workspace in upload will take a very very long time, and the different py_ver workflow tries to persist common files, and it was causing problems.

Test result: https://circleci.com/gh/CDAT/cdtime/tree/makefile_n_matrix